### PR TITLE
update to 'v1.5' go dev env, which updates go to 1.21 and eliminates …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hephy/go-dev:v1.27.1
+FROM hephy/go-dev:v1.5
 # This Dockerfile is used to bundle the source and all dependencies into an image for testing.
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-jessie main" \


### PR DESCRIPTION
…some DNS issues in macos